### PR TITLE
v1.1.0

### DIFF
--- a/examples/Example4-SPI_Simple_measurement/Example4-SPI_Simple_measurement.ino
+++ b/examples/Example4-SPI_Simple_measurement/Example4-SPI_Simple_measurement.ino
@@ -30,11 +30,12 @@ void setup()
 
     SPI.begin();
 
-    if (myMag.begin(csPin) == false)
+    while (myMag.begin(csPin) == false)
     {
-        Serial.println("MMC5983MA did not respond - check your wiring. Freezing.");
-        while (true)
-            ;
+        Serial.println("MMC5983MA did not respond. Retrying...");
+        delay(500);
+        myMag.softReset();
+        delay(500);
     }
 
     Serial.println("MMC5983MA connected");

--- a/examples/Example5-SPI_Digital_compass/Example5-SPI_Digital_compass.ino
+++ b/examples/Example5-SPI_Digital_compass/Example5-SPI_Digital_compass.ino
@@ -30,11 +30,12 @@ void setup()
 
     SPI.begin();
 
-    if (myMag.begin(csPin) == false)
+    while (myMag.begin(csPin) == false)
     {
-        Serial.println("MMC5983MA did not respond - check your wiring. Freezing.");
-        while (true)
-            ;
+        Serial.println("MMC5983MA did not respond. Retrying...");
+        delay(500);
+        myMag.softReset();
+        delay(500);
     }
 
     Serial.println("MMC5983MA connected");

--- a/examples/Example6-SPI_Fast_Continuous_measurement/Example6-SPI_Fast_Continuous_measurement.ino
+++ b/examples/Example6-SPI_Fast_Continuous_measurement/Example6-SPI_Fast_Continuous_measurement.ino
@@ -45,11 +45,12 @@ void setup()
     pinMode(interruptPin, INPUT);
     attachInterrupt(digitalPinToInterrupt(interruptPin), interruptRoutine, RISING);
 
-    if (myMag.begin(csPin) == false)
+    while (myMag.begin(csPin) == false)
     {
-        Serial.println("MMC5983MA did not respond - check your wiring. Freezing.");
-        while (true)
-            ;
+        Serial.println("MMC5983MA did not respond. Retrying...");
+        delay(500);
+        myMag.softReset();
+        delay(500);
     }
 
     myMag.softReset();

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun MMC5983MA Magnetometer Arduino Library
-version=1.0.3
+version=1.1.0
 author=SparkFun Electronics
 maintainer=SparkFun Electronics
 sentence=A I2C/SPI library for the MMC5983MA magnetic compass sensor.

--- a/src/SparkFun_MMC5983MA_Arduino_Library.cpp
+++ b/src/SparkFun_MMC5983MA_Arduino_Library.cpp
@@ -333,11 +333,15 @@ bool SFE_MMC5983MA::is3WireSPIEnabled()
 
 bool SFE_MMC5983MA::performSetOperation()
 {
-    // Since SET bit clears itself we don't need to to through the shadow
-    // register for this - we can send the command directly to the IC.
-    bool success = mmc_io.setRegisterBit(INT_CTRL_0_REG, SET_OPERATION);
+    // Set the SET bit to perform a set operation.
+    // Do this using the shadow register. If we do it with setRegisterBit
+    // (read-modify-write) we end up setting the Auto_SR_en bit too as that
+    // always seems to read as 1...? I don't know why.
+    bool success = setShadowBit(INT_CTRL_0_REG, SET_OPERATION);
 
-    // Wait until bit clears itself.
+    clearShadowBit(INT_CTRL_0_REG, SET_OPERATION, false); // Clear the bit - in shadow memory only
+
+    // Wait for the set operation to complete (500ns).
     delay(1);
 
     return success;
@@ -345,11 +349,15 @@ bool SFE_MMC5983MA::performSetOperation()
 
 bool SFE_MMC5983MA::performResetOperation()
 {
-    // Since RESET bit clears itself we don't need to to through the shadow
-    // register for this - we can send the command directly to the IC.
-    bool success = mmc_io.setRegisterBit(INT_CTRL_0_REG, RESET_OPERATION);
+    // Set the RESET bit to perform a reset operation.
+    // Do this using the shadow register. If we do it with setRegisterBit
+    // (read-modify-write) we end up setting the Auto_SR_en bit too as that
+    // always seems to read as 1...? I don't know why.
+    bool success = setShadowBit(INT_CTRL_0_REG, RESET_OPERATION);
 
-    // Wait until bit clears itself.
+    clearShadowBit(INT_CTRL_0_REG, RESET_OPERATION, false); // Clear the bit - in shadow memory only
+
+    // Wait for the reset operation to complete (500ns).
     delay(1);
 
     return success;

--- a/src/SparkFun_MMC5983MA_Arduino_Library.cpp
+++ b/src/SparkFun_MMC5983MA_Arduino_Library.cpp
@@ -275,9 +275,13 @@ int SFE_MMC5983MA::getTemperature()
 
 bool SFE_MMC5983MA::softReset()
 {
-    // Since SW_RST bit clears itself we don't need to to through the shadow
-    // register for this - we can send the command directly to the IC.
-    bool success = mmc_io.setRegisterBit(INT_CTRL_1_REG, SW_RST);
+    // Set the SW_RST bit to perform a software reset.
+    // Do this using the shadow register. If we do it with setRegisterBit
+    // (read-modify-write) we end up setting the reserved and BW_0 bits too as they
+    // always seems to read as 1...? I don't know why.
+    bool success = setShadowBit(INT_CTRL_1_REG, SW_RST);
+
+    clearShadowBit(INT_CTRL_1_REG, SW_RST, false); // Clear the bit - in shadow memory only
 
     // The reset time is 10 msec. but we'll wait 15 msec. just in case.
     delay(15);

--- a/src/SparkFun_MMC5983MA_Arduino_Library.cpp
+++ b/src/SparkFun_MMC5983MA_Arduino_Library.cpp
@@ -903,9 +903,13 @@ bool SFE_MMC5983MA::isExtraCurrentAppliedNegToPos()
 
 uint32_t SFE_MMC5983MA::getMeasurementX()
 {
-    // Send command to device. TM_M self clears so we can access it directly.
-    if (!mmc_io.setRegisterBit(INT_CTRL_0_REG, TM_M))
+    // Set the TM_M bit to start the measurement.
+    // Do this using the shadow register. If we do it with setRegisterBit
+    // (read-modify-write) we end up setting the Auto_SR_en bit too as that
+    // always seems to read as 1...? I don't know why.
+    if (!setShadowBit(INT_CTRL_0_REG, TM_M))
     {
+        clearShadowBit(INT_CTRL_0_REG, TM_M, false); // Clear the bit - in shadow memory only
         SAFE_CALLBACK(errorCallback, SF_MMC5983MA_ERROR::BUS_ERROR);
         return 0;
     }
@@ -916,6 +920,8 @@ uint32_t SFE_MMC5983MA::getMeasurementX()
         // Wait a little so we won't flood MMC with requests
         delay(1);
     } while (!mmc_io.isBitSet(STATUS_REG, MEAS_M_DONE));
+
+    clearShadowBit(INT_CTRL_0_REG, TM_M, false); // Clear the bit - in shadow memory only
 
     uint32_t result = 0;
     uint8_t buffer[2] = {0};
@@ -933,9 +939,13 @@ uint32_t SFE_MMC5983MA::getMeasurementX()
 
 uint32_t SFE_MMC5983MA::getMeasurementY()
 {
-    // Send command to device. TM_M self clears so we can access it directly.
-    if (!mmc_io.setRegisterBit(INT_CTRL_0_REG, TM_M))
+    // Set the TM_M bit to start the measurement.
+    // Do this using the shadow register. If we do it with setRegisterBit
+    // (read-modify-write) we end up setting the Auto_SR_en bit too as that
+    // always seems to read as 1...? I don't know why.
+    if (!setShadowBit(INT_CTRL_0_REG, TM_M))
     {
+        clearShadowBit(INT_CTRL_0_REG, TM_M, false); // Clear the bit - in shadow memory only
         SAFE_CALLBACK(errorCallback, SF_MMC5983MA_ERROR::BUS_ERROR);
         return 0;
     }
@@ -946,6 +956,8 @@ uint32_t SFE_MMC5983MA::getMeasurementY()
         // Wait a little so we won't flood MMC with requests
         delay(1);
     } while (!mmc_io.isBitSet(STATUS_REG, MEAS_M_DONE));
+
+    clearShadowBit(INT_CTRL_0_REG, TM_M, false); // Clear the bit - in shadow memory only
 
     uint32_t result = 0;
     uint8_t buffer[2] = {0};
@@ -963,9 +975,13 @@ uint32_t SFE_MMC5983MA::getMeasurementY()
 
 uint32_t SFE_MMC5983MA::getMeasurementZ()
 {
-    // Send command to device. TM_M self clears so we can access it directly.
-    if (!mmc_io.setRegisterBit(INT_CTRL_0_REG, TM_M))
+    // Set the TM_M bit to start the measurement.
+    // Do this using the shadow register. If we do it with setRegisterBit
+    // (read-modify-write) we end up setting the Auto_SR_en bit too as that
+    // always seems to read as 1...? I don't know why.
+    if (!setShadowBit(INT_CTRL_0_REG, TM_M))
     {
+        clearShadowBit(INT_CTRL_0_REG, TM_M, false); // Clear the bit - in shadow memory only
         SAFE_CALLBACK(errorCallback, SF_MMC5983MA_ERROR::BUS_ERROR);
         return 0;
     }
@@ -976,6 +992,8 @@ uint32_t SFE_MMC5983MA::getMeasurementZ()
         // Wait a little so we won't flood MMC with requests
         delay(1);
     } while (!mmc_io.isBitSet(STATUS_REG, MEAS_M_DONE));
+
+    clearShadowBit(INT_CTRL_0_REG, TM_M, false); // Clear the bit - in shadow memory only
 
     uint32_t result = 0;
     uint8_t buffer[3] = {0};
@@ -991,11 +1009,15 @@ uint32_t SFE_MMC5983MA::getMeasurementZ()
 
 bool SFE_MMC5983MA::getMeasurementXYZ(uint32_t *x, uint32_t *y, uint32_t *z)
 {
-    // Send command to device. TM_M self clears so we can access it directly.
-    bool success = mmc_io.setRegisterBit(INT_CTRL_0_REG, TM_M);
+    // Set the TM_M bit to start the measurement.
+    // Do this using the shadow register. If we do it with setRegisterBit
+    // (read-modify-write) we end up setting the Auto_SR_en bit too as that
+    // always seems to read as 1...? I don't know why.
+    bool success = setShadowBit(INT_CTRL_0_REG, TM_M);
 
     if (!success)
     {
+        clearShadowBit(INT_CTRL_0_REG, TM_M, false); // Clear the bit - in shadow memory only
         SAFE_CALLBACK(errorCallback, SF_MMC5983MA_ERROR::BUS_ERROR);
         return false;
     }
@@ -1006,6 +1028,8 @@ bool SFE_MMC5983MA::getMeasurementXYZ(uint32_t *x, uint32_t *y, uint32_t *z)
         // Wait a little so we won't flood MMC with requests
         delay(1);
     } while (!mmc_io.isBitSet(STATUS_REG, MEAS_M_DONE));
+
+    clearShadowBit(INT_CTRL_0_REG, TM_M, false); // Clear the bit - in shadow memory only
 
     return (readFieldsXYZ(x, y, z));
 }

--- a/src/SparkFun_MMC5983MA_Arduino_Library.cpp
+++ b/src/SparkFun_MMC5983MA_Arduino_Library.cpp
@@ -406,6 +406,9 @@ bool SFE_MMC5983MA::isXChannelEnabled()
 {
     // Get the bit value from the shadow register since the IC does not
     // allow reading INT_CTRL_1_REG register.
+    //
+    // Note: this returns true when the X channel is inhibited.
+    // Strictly, it should be called isXChannelInhibited.
     return (isShadowBitSet(INT_CTRL_1_REG, X_INHIBIT));
 }
 
@@ -431,6 +434,9 @@ bool SFE_MMC5983MA::areYZChannelsEnabled()
 {
     // Get the bit value from the shadow register since the IC does not
     // allow reading INT_CTRL_1_REG register.
+    //
+    // Note: this returns true when the Y and Z channels are inhibited.
+    // Strictly, it should be called areYZChannelsInhibited.
     return (isShadowBitSet(INT_CTRL_1_REG, YZ_INHIBIT));
 }
 
@@ -444,28 +450,28 @@ bool SFE_MMC5983MA::setFilterBandwidth(uint16_t bandwidth)
     {
     case 800:
     {
-        success = setShadowBit(INT_CTRL_1_REG, BW0);
+        success = setShadowBit(INT_CTRL_1_REG, BW0, false);
         success &= setShadowBit(INT_CTRL_1_REG, BW1);
     }
     break;
 
     case 400:
     {
-        success = clearShadowBit(INT_CTRL_1_REG, BW0);
+        success = clearShadowBit(INT_CTRL_1_REG, BW0, false);
         success &= setShadowBit(INT_CTRL_1_REG, BW1);
     }
     break;
 
     case 200:
     {
-        success = setShadowBit(INT_CTRL_1_REG, BW0);
+        success = setShadowBit(INT_CTRL_1_REG, BW0, false);
         success &= clearShadowBit(INT_CTRL_1_REG, BW1);
     }
     break;
 
     case 100:
     {
-        success = clearShadowBit(INT_CTRL_1_REG, BW0);
+        success = clearShadowBit(INT_CTRL_1_REG, BW0, false);
         success &= clearShadowBit(INT_CTRL_1_REG, BW1);
     }
     break;
@@ -543,8 +549,8 @@ bool SFE_MMC5983MA::setContinuousModeFrequency(uint16_t frequency)
     case 1:
     {
         // CM_FREQ[2:0] = 001
-        success = clearShadowBit(INT_CTRL_2_REG, CM_FREQ_2);
-        success &= clearShadowBit(INT_CTRL_2_REG, CM_FREQ_1);
+        success = clearShadowBit(INT_CTRL_2_REG, CM_FREQ_2, false);
+        success &= clearShadowBit(INT_CTRL_2_REG, CM_FREQ_1, false);
         success &= setShadowBit(INT_CTRL_2_REG, CM_FREQ_0);
     }
     break;
@@ -552,8 +558,8 @@ bool SFE_MMC5983MA::setContinuousModeFrequency(uint16_t frequency)
     case 10:
     {
         // CM_FREQ[2:0] = 010
-        success = clearShadowBit(INT_CTRL_2_REG, CM_FREQ_2);
-        success &= setShadowBit(INT_CTRL_2_REG, CM_FREQ_1);
+        success = clearShadowBit(INT_CTRL_2_REG, CM_FREQ_2, false);
+        success &= setShadowBit(INT_CTRL_2_REG, CM_FREQ_1, false);
         success &= clearShadowBit(INT_CTRL_2_REG, CM_FREQ_0);
     }
     break;
@@ -561,8 +567,8 @@ bool SFE_MMC5983MA::setContinuousModeFrequency(uint16_t frequency)
     case 20:
     {
         // CM_FREQ[2:0] = 011
-        success = clearShadowBit(INT_CTRL_2_REG, CM_FREQ_2);
-        success &= setShadowBit(INT_CTRL_2_REG, CM_FREQ_1);
+        success = clearShadowBit(INT_CTRL_2_REG, CM_FREQ_2, false);
+        success &= setShadowBit(INT_CTRL_2_REG, CM_FREQ_1, false);
         success &= setShadowBit(INT_CTRL_2_REG, CM_FREQ_0);
     }
     break;
@@ -570,8 +576,8 @@ bool SFE_MMC5983MA::setContinuousModeFrequency(uint16_t frequency)
     case 50:
     {
         // CM_FREQ[2:0] = 100
-        success = setShadowBit(INT_CTRL_2_REG, CM_FREQ_2);
-        success &= clearShadowBit(INT_CTRL_2_REG, CM_FREQ_1);
+        success = setShadowBit(INT_CTRL_2_REG, CM_FREQ_2, false);
+        success &= clearShadowBit(INT_CTRL_2_REG, CM_FREQ_1, false);
         success &= clearShadowBit(INT_CTRL_2_REG, CM_FREQ_0);
     }
     break;
@@ -579,8 +585,8 @@ bool SFE_MMC5983MA::setContinuousModeFrequency(uint16_t frequency)
     case 100:
     {
         // CM_FREQ[2:0] = 101
-        success = setShadowBit(INT_CTRL_2_REG, CM_FREQ_2);
-        success &= clearShadowBit(INT_CTRL_2_REG, CM_FREQ_1);
+        success = setShadowBit(INT_CTRL_2_REG, CM_FREQ_2, false);
+        success &= clearShadowBit(INT_CTRL_2_REG, CM_FREQ_1, false);
         success &= setShadowBit(INT_CTRL_2_REG, CM_FREQ_0);
     }
     break;
@@ -588,8 +594,8 @@ bool SFE_MMC5983MA::setContinuousModeFrequency(uint16_t frequency)
     case 200:
     {
         // CM_FREQ[2:0] = 110
-        success = setShadowBit(INT_CTRL_2_REG, CM_FREQ_2);
-        success &= setShadowBit(INT_CTRL_2_REG, CM_FREQ_1);
+        success = setShadowBit(INT_CTRL_2_REG, CM_FREQ_2, false);
+        success &= setShadowBit(INT_CTRL_2_REG, CM_FREQ_1, false);
         success &= clearShadowBit(INT_CTRL_2_REG, CM_FREQ_0);
     }
     break;
@@ -597,8 +603,8 @@ bool SFE_MMC5983MA::setContinuousModeFrequency(uint16_t frequency)
     case 1000:
     {
         // CM_FREQ[2:0] = 111
-        success = setShadowBit(INT_CTRL_2_REG, CM_FREQ_2);
-        success &= setShadowBit(INT_CTRL_2_REG, CM_FREQ_1);
+        success = setShadowBit(INT_CTRL_2_REG, CM_FREQ_2, false);
+        success &= setShadowBit(INT_CTRL_2_REG, CM_FREQ_1, false);
         success &= setShadowBit(INT_CTRL_2_REG, CM_FREQ_0);
     }
     break;
@@ -606,8 +612,8 @@ bool SFE_MMC5983MA::setContinuousModeFrequency(uint16_t frequency)
     case 0:
     {
         // CM_FREQ[2:0] = 000
-        success = clearShadowBit(INT_CTRL_2_REG, CM_FREQ_2);
-        success &= clearShadowBit(INT_CTRL_2_REG, CM_FREQ_1);
+        success = clearShadowBit(INT_CTRL_2_REG, CM_FREQ_2, false);
+        success &= clearShadowBit(INT_CTRL_2_REG, CM_FREQ_1, false);
         success &= clearShadowBit(INT_CTRL_2_REG, CM_FREQ_0);
     }
     break;
@@ -717,8 +723,8 @@ bool SFE_MMC5983MA::setPeriodicSetSamples(const uint16_t numberOfSamples)
     case 25:
     {
         // PRD_SET[2:0] = 001
-        success = clearShadowBit(INT_CTRL_2_REG, PRD_SET_2);
-        success &= clearShadowBit(INT_CTRL_2_REG, PRD_SET_1);
+        success = clearShadowBit(INT_CTRL_2_REG, PRD_SET_2, false);
+        success &= clearShadowBit(INT_CTRL_2_REG, PRD_SET_1, false);
         success &= setShadowBit(INT_CTRL_2_REG, PRD_SET_0);
     }
     break;
@@ -726,8 +732,8 @@ bool SFE_MMC5983MA::setPeriodicSetSamples(const uint16_t numberOfSamples)
     case 75:
     {
         // PRD_SET[2:0] = 010
-        success = clearShadowBit(INT_CTRL_2_REG, PRD_SET_2);
-        success &= setShadowBit(INT_CTRL_2_REG, PRD_SET_1);
+        success = clearShadowBit(INT_CTRL_2_REG, PRD_SET_2, false);
+        success &= setShadowBit(INT_CTRL_2_REG, PRD_SET_1, false);
         success &= clearShadowBit(INT_CTRL_2_REG, PRD_SET_0);
     }
     break;
@@ -735,8 +741,8 @@ bool SFE_MMC5983MA::setPeriodicSetSamples(const uint16_t numberOfSamples)
     case 100:
     {
         // PRD_SET[2:0] = 011
-        success = clearShadowBit(INT_CTRL_2_REG, PRD_SET_2);
-        success &= setShadowBit(INT_CTRL_2_REG, PRD_SET_1);
+        success = clearShadowBit(INT_CTRL_2_REG, PRD_SET_2, false);
+        success &= setShadowBit(INT_CTRL_2_REG, PRD_SET_1, false);
         success &= setShadowBit(INT_CTRL_2_REG, PRD_SET_0);
     }
     break;
@@ -744,8 +750,8 @@ bool SFE_MMC5983MA::setPeriodicSetSamples(const uint16_t numberOfSamples)
     case 250:
     {
         // PRD_SET[2:0] = 100
-        success = setShadowBit(INT_CTRL_2_REG, PRD_SET_2);
-        success &= clearShadowBit(INT_CTRL_2_REG, PRD_SET_1);
+        success = setShadowBit(INT_CTRL_2_REG, PRD_SET_2, false);
+        success &= clearShadowBit(INT_CTRL_2_REG, PRD_SET_1, false);
         success &= clearShadowBit(INT_CTRL_2_REG, PRD_SET_0);
     }
     break;
@@ -753,8 +759,8 @@ bool SFE_MMC5983MA::setPeriodicSetSamples(const uint16_t numberOfSamples)
     case 500:
     {
         // PRD_SET[2:0] = 101
-        success = setShadowBit(INT_CTRL_2_REG, PRD_SET_2);
-        success &= clearShadowBit(INT_CTRL_2_REG, PRD_SET_1);
+        success = setShadowBit(INT_CTRL_2_REG, PRD_SET_2, false);
+        success &= clearShadowBit(INT_CTRL_2_REG, PRD_SET_1, false);
         success &= setShadowBit(INT_CTRL_2_REG, PRD_SET_0);
     }
     break;
@@ -762,8 +768,8 @@ bool SFE_MMC5983MA::setPeriodicSetSamples(const uint16_t numberOfSamples)
     case 1000:
     {
         // PRD_SET[2:0] = 110
-        success = setShadowBit(INT_CTRL_2_REG, PRD_SET_2);
-        success &= setShadowBit(INT_CTRL_2_REG, PRD_SET_1);
+        success = setShadowBit(INT_CTRL_2_REG, PRD_SET_2, false);
+        success &= setShadowBit(INT_CTRL_2_REG, PRD_SET_1, false);
         success &= clearShadowBit(INT_CTRL_2_REG, PRD_SET_0);
     }
     break;
@@ -771,8 +777,8 @@ bool SFE_MMC5983MA::setPeriodicSetSamples(const uint16_t numberOfSamples)
     case 2000:
     {
         // PRD_SET[2:0] = 111
-        success = setShadowBit(INT_CTRL_2_REG, PRD_SET_2);
-        success &= setShadowBit(INT_CTRL_2_REG, PRD_SET_1);
+        success = setShadowBit(INT_CTRL_2_REG, PRD_SET_2, false);
+        success &= setShadowBit(INT_CTRL_2_REG, PRD_SET_1, false);
         success &= setShadowBit(INT_CTRL_2_REG, PRD_SET_0);
     }
     break;
@@ -780,8 +786,8 @@ bool SFE_MMC5983MA::setPeriodicSetSamples(const uint16_t numberOfSamples)
     case 1:
     {
         // PRD_SET[2:0] = 000
-        success = clearShadowBit(INT_CTRL_2_REG, PRD_SET_2);
-        success &= clearShadowBit(INT_CTRL_2_REG, PRD_SET_1);
+        success = clearShadowBit(INT_CTRL_2_REG, PRD_SET_2, false);
+        success &= clearShadowBit(INT_CTRL_2_REG, PRD_SET_1, false);
         success &= clearShadowBit(INT_CTRL_2_REG, PRD_SET_0);
     }
     break;

--- a/src/SparkFun_MMC5983MA_Arduino_Library.cpp
+++ b/src/SparkFun_MMC5983MA_Arduino_Library.cpp
@@ -1068,6 +1068,10 @@ bool SFE_MMC5983MA::readFieldsXYZ(uint32_t *x, uint32_t *y, uint32_t *z)
 
 bool SFE_MMC5983MA::clearMeasDoneInterrupt(uint8_t measMask)
 {
-    measMask &= (MEAS_T_DONE | MEAS_M_DONE); // Ensure only the Meas_T_Done and Meas_M_Done interrupts can be cleared
-    return (mmc_io.setRegisterBit(STATUS_REG, measMask)); // Writing 1 into these bits will clear the corresponding interrupt
+    // Ensure only the Meas_T_Done and Meas_M_Done interrupts can be cleared
+    measMask &= (MEAS_T_DONE | MEAS_M_DONE);
+
+    // Writing 1 into these bits will clear the corresponding interrupt
+    // Read-modify-write is OK here
+    return (mmc_io.setRegisterBit(STATUS_REG, measMask));
 }

--- a/src/SparkFun_MMC5983MA_Arduino_Library.h
+++ b/src/SparkFun_MMC5983MA_Arduino_Library.h
@@ -42,11 +42,11 @@ private:
     uint8_t internalControl3 = 0x0;
   } memoryShadow;
 
-  // Sets register bit(s) on memory shadows and then registers
-  bool setShadowBit(uint8_t registerAddress, const uint8_t bitMask);
+  // Sets register bit(s) on memory shadows and then registers (if doWrite is true)
+  bool setShadowBit(uint8_t registerAddress, const uint8_t bitMask, bool doWrite = true);
 
-  // Clears register bit(s) on memory shadows and then registers
-  bool clearShadowBit(uint8_t registerAddress, const uint8_t bitMask);
+  // Clears register bit(s) on memory shadows and then registers (if doWrite is true)
+  bool clearShadowBit(uint8_t registerAddress, const uint8_t bitMask, bool doWrite = true);
 
   // Checks if a specific bit is set on a register memory shadow
   bool isShadowBitSet(uint8_t registerAddress, const uint8_t bitMask);

--- a/src/SparkFun_MMC5983MA_Arduino_Library.h
+++ b/src/SparkFun_MMC5983MA_Arduino_Library.h
@@ -121,6 +121,8 @@ public:
   bool disableXChannel();
 
   // Checks if X channel output is enabled
+  // Note: this returns true when the X channel is inhibited.
+  // Strictly, it should be called isXChannelInhibited.
   bool isXChannelEnabled();
 
   // Enables Y and Z channels outputs
@@ -130,6 +132,8 @@ public:
   bool disableYZChannels();
 
   // Checks if YZ channels outputs are enabled
+  // Note: this returns true when the Y and Z channels are inhibited.
+  // Strictly, it should be called areYZChannelsInhibited.
   bool areYZChannelsEnabled();
 
   // Sets decimation filter bandwidth. Allowed values are 800, 400, 200 or 100. Defaults to 100 on invalid values.


### PR DESCRIPTION
This release:
* Corrects a tricky bug which meant the chip was always in Auto-Set-Reset mode
  * As reported in #9
  * Probably also explains #8
* Updates the SPI examples
  * It's rare, but I've sometimes seen ```begin``` fail on SPI as the chip returns the wrong Product ID (0xFF instead of 0x30)
  * Performing a ```softReset``` fixes it - by making the chip re-read its OTP memory
  * It's OK to call ```softReset``` so long as you have called ```begin``` at least once. (Calling ```softReset``` before ```begin``` will cause a crash.)